### PR TITLE
Update balena.yml

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -1,4 +1,3 @@
-version: "2"
 slug: "balena-dashboards"
 name: "balenaDashboards"
 type: "sw.application"


### PR DESCRIPTION
The version field is now used for semantic versioning of releases rather than versioning of the yml file itself, so we can just remove it to save each release getting version '2.0.0'.